### PR TITLE
카테고리별 장소 검색 기능 추가

### DIFF
--- a/src/main/java/com/project/nearby/api/KakaoCategorySearchService.java
+++ b/src/main/java/com/project/nearby/api/KakaoCategorySearchService.java
@@ -1,0 +1,53 @@
+package com.project.nearby.api;
+
+import com.project.nearby.api.dto.KakaoCategorySearchResponseDto;
+import com.project.nearby.api.enumeration.CategoryGroupCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.Objects;
+
+@Service
+@Slf4j
+public class KakaoCategorySearchService {
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${kakao.rest.api.key}")
+    private String KakaoRestApiKey;
+
+    // 카테고리 검색
+
+    /**
+     * 장소 검색하기
+     * @param code 카테고리 그룹 코드
+     * @param lng 경도
+     * @param lat 위도
+     * @param radius 검색 반경
+     * @return
+     */
+    public KakaoCategorySearchResponseDto search(CategoryGroupCode code, String lng, String lat, Integer radius) {
+
+        // URI 생성
+        URI uri = KakaoUriBuilderService.getUriForCategorySearch(code, lng, lat, radius);
+
+        if (Objects.isNull(uri)) {
+            return null;
+        }
+
+        // Header 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + KakaoRestApiKey);
+
+        HttpEntity httpEntity = new HttpEntity(headers);
+
+        return restTemplate
+                .exchange(uri, HttpMethod.GET, httpEntity, KakaoCategorySearchResponseDto.class)
+                .getBody();
+    }
+}

--- a/src/main/java/com/project/nearby/api/KakaoUriBuilderService.java
+++ b/src/main/java/com/project/nearby/api/KakaoUriBuilderService.java
@@ -1,24 +1,55 @@
 package com.project.nearby.api;
 
+import com.project.nearby.api.enumeration.CategoryGroupCode;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.Objects;
 
 public final class KakaoUriBuilderService {
 
     private static final String REQUEST_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+    private static final String CATEGORY_PLACE_SEARCH_URL = "https://dapi.kakao.com/v2/local/search/category.json";
 
     private KakaoUriBuilderService() {
     }
 
     /**
      * 주소를 좌표로 변환하기 위한 URI 제작
+     *
      * @param address 도로명 주소(또는 지번 주소)
      */
     public static URI getRequestUriForAddressToCoordinate(String address) {
         return UriComponentsBuilder
                 .fromUriString(REQUEST_URL)
                 .queryParam("query", address)   // 쿼리 파라미터 추가
+                .build()
+                .encode()
+                .toUri();
+    }
+
+    /**
+     * 카테고리로 장소 검색을 위한 URI 제작
+     * @param code
+     * @param lng 경도
+     * @param lat 위도
+     * @param radius 검색 반경(단위: m, 0 ~ 20_000 사이 값)
+     */
+    public static URI getUriForCategorySearch(CategoryGroupCode code, String lng, String lat, Integer radius) {
+        if (Objects.isNull(code) || Objects.isNull(lng) || Objects.isNull(lat) || Objects.isNull(radius)) {
+            return null;
+        }
+
+        if (radius < 0 || radius > 20_000) {
+            return null;
+        }
+
+        return UriComponentsBuilder
+                .fromUriString(CATEGORY_PLACE_SEARCH_URL)
+                .queryParam("category_group_code", code.getCode())
+                .queryParam("x", lng)
+                .queryParam("y", lat)
+                .queryParam("radius", radius)
                 .build()
                 .encode()
                 .toUri();

--- a/src/main/java/com/project/nearby/api/dto/CategorySearchDto.java
+++ b/src/main/java/com/project/nearby/api/dto/CategorySearchDto.java
@@ -1,0 +1,38 @@
+package com.project.nearby.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class CategorySearchDto {
+
+    @JsonProperty("place_name")
+    private String placeName;   // 장소명, 업체명
+
+    @JsonProperty("phone")
+    private String phone;   // 전화번호
+
+    @JsonProperty("address_name")
+    private String addressName; // 지번 주소
+
+    @JsonProperty("road_address_name")
+    private String roadAddressName; // 도로명 주소
+
+    @JsonProperty("x")
+    private String longitude;   // 경도
+
+    @JsonProperty("y")
+    private String latitude;    // 위도
+
+    @JsonProperty("placeUrl")
+    private String placeUrl;    // 장소 상세 페이지 URL
+
+    @JsonProperty("distance")
+    private String distance;    // 중심좌표까지의 거리(단위: m)
+}

--- a/src/main/java/com/project/nearby/api/dto/KakaoCategorySearchResponseDto.java
+++ b/src/main/java/com/project/nearby/api/dto/KakaoCategorySearchResponseDto.java
@@ -1,0 +1,21 @@
+package com.project.nearby.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoCategorySearchResponseDto {
+
+    @JsonProperty("meta")
+    private KakaoApiMetaDto metaDto;
+
+    @JsonProperty("documents")
+    private List<CategorySearchDto> categorySearchDtos;
+
+}

--- a/src/main/java/com/project/nearby/api/enumeration/CategoryGroupCode.java
+++ b/src/main/java/com/project/nearby/api/enumeration/CategoryGroupCode.java
@@ -1,0 +1,40 @@
+package com.project.nearby.api.enumeration;
+
+public enum CategoryGroupCode {
+    MART("MT1", "대형마트"),
+    CONVENIENCE_STORE("CS2", "편의점"),
+    KINDERGARTEN("PS3", "어린이집, 유치원"),
+    SCHOOL("SC4", "학교"),
+    ACADEMY("AC5", "학원"),
+    PARKING_LOT("PK6", "주차장"),
+    GAS_STATION("OL7", "주유소, 충전소"),
+    SUBWAY_STATION("SW8", "지하철역"),
+    BANK("BK9", "은행"),
+    CULTURE_FACILITY("CT1", "문화시설"),
+    AGENCY("AG2", "중개업소"),
+    PUBLIC_INSTITUTION("PO3", "공공기관"),
+    TOURIST_SPOT("AT4", "관광명소"),
+    ACCOMMODATION("AD5", "숙박"),
+    RESTAURANT("FD6", "음식점"),
+    CAFE("CE7", "카페"),
+    HOSPITAL("HP8", "병원"),
+    PHARMACY("PM9", "약국");
+
+    private final String code;         // 카테고리 코드
+    private final String description;   // 카테고리 설명
+
+    CategoryGroupCode(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}
+
+

--- a/src/test/java/com/project/nearby/api/KakaoCategorySearchServiceTest.java
+++ b/src/test/java/com/project/nearby/api/KakaoCategorySearchServiceTest.java
@@ -1,0 +1,91 @@
+package com.project.nearby.api;
+
+import com.project.nearby.api.dto.KakaoCategorySearchResponseDto;
+import com.project.nearby.api.enumeration.CategoryGroupCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+class KakaoCategorySearchServiceTest {
+
+    @Autowired
+    private KakaoCategorySearchService kakaoCategorySearchService;
+
+    private final CategoryGroupCode code = CategoryGroupCode.MART;
+    private final String lng = "126.981408909449";
+    private final String lat = "37.4765228347619";
+    private final Integer radius = 10_000;
+
+    @Test
+    @DisplayName("카테고리 검색 성공 - 유효한 값을 입력하면 정상적으로 값을 받아옴")
+    void searchPlacesSuccess() {
+        // given
+
+        // when
+//        KakaoCategorySearchResponseDto response = kakaoCategorySearchService.search(code, lng, lat, radius);
+        KakaoCategorySearchResponseDto response = kakaoCategorySearchService.search(code, "", "", radius);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getMetaDto()).isNotNull();
+        assertTrue(response.getCategorySearchDtos().size() > 0);
+
+    }
+
+    @Test
+    @DisplayName("카테고리 검색 실패 - 카테고리 그룹 코드에 null 입력 시")
+    void searchFailWhenUsingNullCategoryGroupCode() {
+        // given
+        CategoryGroupCode categoryGroupCode = null;
+
+        // when
+        KakaoCategorySearchResponseDto response = kakaoCategorySearchService.search(categoryGroupCode, lng, lat, radius);
+
+        // then
+        assertThat(response).isNull();
+    }
+
+    @Test
+    @DisplayName("카테고리 검색 실패 - 위도에 null 입력 시")
+    void searchFailWhenUsingNullLongitude() {
+        // given
+        String longitude = null;
+
+        // when
+        KakaoCategorySearchResponseDto response = kakaoCategorySearchService.search(code, longitude, lat, radius);
+
+        // then
+        assertThat(response).isNull();
+    }
+
+    @Test
+    @DisplayName("카테고리 검색 실패 - 경도에 null 입력 시")
+    void searchFailWhenUsingNullLatitude() {
+        // given
+        String latitude = null;
+
+        // when
+        KakaoCategorySearchResponseDto response = kakaoCategorySearchService.search(code, lng, latitude, radius);
+
+        // then
+        assertThat(response).isNull();
+    }
+
+    @Test
+    @DisplayName("카테고리 검색 실패 - 검색 반경에 null 입력 시")
+    void searchFailWhenUsingNullRadius() {
+        // given
+        Integer value = null;
+
+        // when
+        KakaoCategorySearchResponseDto response = kakaoCategorySearchService.search(code, lng, lat, value);
+
+        // then
+        assertThat(response).isNull();
+    }
+}

--- a/src/test/java/com/project/nearby/api/KakaoUriBuilderServiceTest.java
+++ b/src/test/java/com/project/nearby/api/KakaoUriBuilderServiceTest.java
@@ -1,6 +1,6 @@
 package com.project.nearby.api;
 
-import org.assertj.core.api.Assertions;
+import com.project.nearby.api.enumeration.CategoryGroupCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -8,7 +8,15 @@ import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class KakaoUriBuilderServiceTest {
+
+    private final String categorySearchUrl = "https://dapi.kakao.com/v2/local/search/category.json";
+    private CategoryGroupCode code = CategoryGroupCode.MART;
+    private String lng = "126.981408909449";
+    private String lat = "37.4765228347619";
+    Integer radius = 1000;
 
     @Test
     @DisplayName("한글 파라미터 정상적으로 인코딩")
@@ -22,6 +30,97 @@ class KakaoUriBuilderServiceTest {
         String decoded = URLDecoder.decode(uri.toString(), StandardCharsets.UTF_8);
 
         // then
-        Assertions.assertThat(decoded).isEqualTo(urlTemplate + address);
+        assertThat(decoded).isEqualTo(urlTemplate + address);
+    }
+
+    @Test
+    @DisplayName("카테고리 검색 URI - 한글 파라미터 정상적으로 인코딩")
+    void buildCategorySearchUri() {
+        // given
+
+        // when
+        URI uri = KakaoUriBuilderService.getUriForCategorySearch(code, lng, lat, radius);
+        String decode = URLDecoder.decode(uri.toString(), StandardCharsets.UTF_8);
+
+        // then
+        String expected = String.format(
+                "%s?category_group_code=%s&x=%s&y=%s&radius=%s", categorySearchUrl, code.getCode(), lng, lat, radius
+        );
+        assertThat(decode).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("카테고리 검색 URI 생성 성공 - 유효한 범위의 반경 입력 시 성공적으로 URI 생성")
+    void getAvailableUriWhenUsingAvailableRadius() {
+        // given
+        Integer[] arr = new Integer[]{0, 100, 1000, 10_000, 20_000};
+
+        for (Integer validRadius : arr) {
+            // when
+            URI uri = KakaoUriBuilderService.getUriForCategorySearch(code, lng, lat, validRadius);
+            String decoded = URLDecoder.decode(uri.toString(), StandardCharsets.UTF_8);
+
+            // then
+            String expected = String.format(
+                    "%s?category_group_code=%s&x=%s&y=%s&radius=%s",
+                    categorySearchUrl, code.getCode(), lng, lat, validRadius
+            );
+
+            assertThat(decoded).isEqualTo(expected);
+        }
+    }
+
+    @Test
+    @DisplayName("카테고리 검색 URI 생성 실패 - 유효하지 않은 범위의 반경 입력 시 null 반환")
+    void getNullWhenUsingUnavailableRadius() {
+        // given
+        Integer[] arr = new Integer[]{-1, 20_001};
+
+        for (Integer invalidRadius : arr) {
+            // when
+            URI uri = KakaoUriBuilderService.getUriForCategorySearch(code, lng, lat, invalidRadius);
+
+            // then
+            assertThat(uri).isNull();
+        }
+    }
+
+    @Test
+    @DisplayName("카테고리 검색 URI 생성 실패 - 카테고리 그룹 코드에 null 입력 시 null 반환")
+    void getNullWhenUsingNullCategoryGroupCode() {
+        // given
+        CategoryGroupCode categoryGroupCode = null;
+
+        // when
+        URI uri = KakaoUriBuilderService.getUriForCategorySearch(categoryGroupCode, lng, lat, radius);
+
+        // then
+        assertThat(uri).isNull();
+    }
+
+    @Test
+    @DisplayName("카테고리 검색 URI 생성 실패 - 경도에 null 입력 시 null 반환")
+    void getNullWhenUsingNullLongitude() {
+        // given
+        String longitude = null;
+
+        // when
+        URI uri = KakaoUriBuilderService.getUriForCategorySearch(code, longitude, lat, radius);
+
+        // then
+        assertThat(uri).isNull();
+    }
+
+    @Test
+    @DisplayName("카테고리 검색 URI 생성 실패 - 위도에 null 입력 시 null 반환")
+    void getNullWhenUsingNullLatitude() {
+        // given
+        String latitude = null;
+
+        // when
+        URI uri = KakaoUriBuilderService.getUriForCategorySearch(code, lng, latitude, radius);
+
+        // then
+        assertThat(uri).isNull();
     }
 }


### PR DESCRIPTION
- 카테고리 그룹 코드, 경도, 위도, 검색 반경을 카카오 서버로 보내 응답으로 장소 리스트를 받아옴
- 카테고리 그룹 코드의 경우 enum으로 관리